### PR TITLE
added support for multiple 'should match snapshot' tests

### DIFF
--- a/src/getTestName.js
+++ b/src/getTestName.js
@@ -1,0 +1,11 @@
+module.exports = function getTestName(context) {
+  let ctxPath = [context.title];
+  let stepParent = context.runnable.parent;
+  while (stepParent) {
+    if (stepParent.title) {
+      ctxPath.unshift(stepParent.title);
+    }
+    stepParent = stepParent.parent;
+  }
+  return ctxPath.join('/').trim();
+};

--- a/src/matchSnapshot.js
+++ b/src/matchSnapshot.js
@@ -5,6 +5,7 @@ const getPrintableDiff    = require('./getPrintableDiff')
 const getExistingSnaps    = require('./getExistingSnaps')
 const getNormalizedTarget = require('./getNormalizedTarget')
 const persistSnaps        = require('./persistSnaps')
+const getTestName         = require('./getTestName')
 
 const snapshotExtension     = '.mocha-snapshot'
 const snapshotsFolder       = '__snapshots__'
@@ -15,7 +16,7 @@ module.exports = function (value, context) {
   const fileName         = path.basename(context.runnable.file)
   const snapshotDir      = path.join(dirName, snapshotsFolder)
   const snapshotFilePath = path.join(snapshotDir, fileName + snapshotExtension)
-  const testName         = context.title + '(' + (context.titleIndex++) + ')'
+  const testName         = getTestName(context) + '(' + (context.titleIndex++) + ')'
   const snaps            = getExistingSnaps(snapshotDir, snapshotFilePath)
   const target           = getNormalizedTarget(value)
 

--- a/tests/__snapshots__/matchSnapshot.test.js.mocha-snapshot
+++ b/tests/__snapshots__/matchSnapshot.test.js.mocha-snapshot
@@ -1,4 +1,13 @@
-exports["should match snapshots(0)"] = {
+exports["matchSnapshot/should match snapshots(0)"] = {
+  "node": {
+    "nodeType": "host",
+    "type": "div",
+    "props": {
+      "className": "abc",
+      "children": "Lorem Ipsum dolor"
+    },
+    "rendered": "Lorem Ipsum dolor"
+  },
   "type": "div",
   "props": {
     "className": "abc"
@@ -8,16 +17,25 @@ exports["should match snapshots(0)"] = {
   ]
 };
 
-exports["should match snapshots(1)"] = 123;
+exports["matchSnapshot/should match snapshots(1)"] = 123;
 
-exports["should match snapshots(2)"] = {
+exports["matchSnapshot/should match snapshots(2)"] = {
   "a": 1,
   "b": {
     "c": "lorem"
   }
 };
 
-exports["should match snapshots without classNames sanitization(0)"] = {
+exports["matchSnapshot/should match snapshots without classNames sanitization(0)"] = {
+  "node": {
+    "nodeType": "host",
+    "type": "div",
+    "props": {
+      "className": "abc-123-45",
+      "children": "Lorem Ipsum dolor"
+    },
+    "rendered": "Lorem Ipsum dolor"
+  },
   "type": "div",
   "props": {
     "className": "abc-123-45"
@@ -26,4 +44,8 @@ exports["should match snapshots without classNames sanitization(0)"] = {
     "Lorem Ipsum dolor"
   ]
 };
+
+exports["matchSnapshot/multiple tests with same it() title/title one/should match snapshot(0)"] = 123;
+
+exports["matchSnapshot/multiple tests with same it() title/title two/should match snapshot(0)"] = 321;
 

--- a/tests/matchSnapshot.test.js
+++ b/tests/matchSnapshot.test.js
@@ -15,6 +15,20 @@ function MyReactComponent() {
 }
 
 describe('matchSnapshot', () => {
+  describe('multiple tests with same it() title', () => {
+    describe('title one', () => {
+      it('should match snapshot', () => {
+        expect(123).to.matchSnapshot()
+      })
+    })
+
+    describe('title two', () => {
+      it('should match snapshot', () => {
+        expect(321).to.matchSnapshot()
+      })
+    })
+  })
+
   it('should match snapshots', () => {
     const wrapper = shallow(<MyReactComponent/>)
 


### PR DESCRIPTION
When using a structure where the nested describe blocks have different titles and the underlying it() block just says "should match snapshot" the current version fails. Added full path support for nested describe blocks.