### PR TITLE
[Backward-incompatible] use pretty-format for serializing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
-# Mocha Snapshots
-Snapshot/regression testing for using with Mocha, specially for React+Enzyme users.
+# Chai Snapshots
+Snapshot/regression testing for using with Chai, specially for React+Enzyme users.
+
+**Based on mocha-snapshot https://github.com/wellguimaraes/mocha-snapshots**
+
+It has incompatible difference - it uses `pretty-print` instead of JSON
 
 ## Install it
-`npm i mocha-snapshots --save`
+`npm i chai-snapshots --save-dev`
 
 ## Use it
 ```es6
@@ -33,12 +37,12 @@ describe('<MyComponent />', () => {
 ## Run your tests
 Add a require argument to your test script/command 
 
-`mocha --require mocha-snapshots`
+`mocha --require chai-snapshots`
 
 ## Disable classNames cleanup
 To prevent false mismatches, mocha-snapshots sanitizes className props by default. You can disable this behavior before running your tests:
 ```js
-import mochaSnapshots from 'mocha-snapshots';
+import mochaSnapshots from 'chai-snapshots';
 
 mochaSnapshots.setup({ sanitizeClassNames: false })
 ```
@@ -47,9 +51,9 @@ mochaSnapshots.setup({ sanitizeClassNames: false })
 Set an environment variable `UPDATE` and run your test script or add the flag `--update`  when running Mocha:
 
 ```
-UPDATE=1 mocha --require mocha-snapshots
+UPDATE=1 mocha --require chai-snapshots
 ``` 
 or
 ```
-mocha --require mocha-snapshots --update
+mocha --require chai-snapshots --update
 ```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Snapshot/regression testing for using with Chai, specially for React+Enzyme user
 It has incompatible difference - it uses `pretty-print` instead of JSON
 
 ## Install it
-`npm i chai-snapshots --save-dev`
+`npm i mocha-chai-snapshots --save-dev`
 
 ## Use it
 ```es6
@@ -37,12 +37,12 @@ describe('<MyComponent />', () => {
 ## Run your tests
 Add a require argument to your test script/command 
 
-`mocha --require chai-snapshots`
+`mocha --require mocha-chai-snapshots`
 
 ## Disable classNames cleanup
 To prevent false mismatches, mocha-snapshots sanitizes className props by default. You can disable this behavior before running your tests:
 ```js
-import mochaSnapshots from 'chai-snapshots';
+import mochaSnapshots from 'mocha-chai-snapshots';
 
 mochaSnapshots.setup({ sanitizeClassNames: false })
 ```
@@ -51,9 +51,9 @@ mochaSnapshots.setup({ sanitizeClassNames: false })
 Set an environment variable `UPDATE` and run your test script or add the flag `--update`  when running Mocha:
 
 ```
-UPDATE=1 mocha --require chai-snapshots
+UPDATE=1 mocha --require mocha-chai-snapshots
 ``` 
 or
 ```
-mocha --require chai-snapshots --update
+mocha --require mocha-chai-snapshots --update
 ```

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "mocha-snapshots",
-  "version": "4.2.0",
-  "description": "Snapshot testing for Mocha users",
+  "name": "chai-snapshots",
+  "version": "1.0.0",
+  "description": "Snapshot testing for Mocha + Chai users",
   "main": "./src/index.js",
   "scripts": {
     "test": "mocha ./tests/**/**/*.test.js -r ./src/index -r babel-polyfill -r babel-register"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/wellguimaraes/mocha-snapshots.git"
+    "url": "git+https://github.com/Short-cm/chai-snapshots.git"
   },
   "keywords": [
     "mocha",
@@ -17,16 +17,17 @@
     "test",
     "testing"
   ],
-  "author": "Wellington Guimaraes <wellguimaraes@gmail.com>",
+  "author": "Wellington Guimaraes <wellguimaraes@gmail.com>, Andrii Kostenko <andrii@short.cm>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/wellguimaraes/mocha-snapshots/issues"
+    "url": "https://github.com/Short-cm/chai-snapshots/issues"
   },
-  "homepage": "https://github.com/wellguimaraes/mocha-snapshots#readme",
+  "homepage": "https://github.com/Short-cm/chai-snapshots#readme",
   "dependencies": {
     "colors": "^1.3.3",
     "diff": "^3.5.0",
-    "enzyme-to-json": "^3.3.5"
+    "enzyme-to-json": "^3.3.5",
+    "pretty-format": "^24.8.0"
   },
   "peerDependencies": {
     "enzyme-adapter-react-16": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mocha-chai-snapshots",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Snapshot testing for Mocha + Chai users",
   "main": "./src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "chai-snapshots",
+  "name": "mocha-chai-snapshots",
   "version": "1.0.0",
   "description": "Snapshot testing for Mocha + Chai users",
   "main": "./src/index.js",
@@ -12,6 +12,7 @@
   },
   "keywords": [
     "mocha",
+    "chai",
     "snapshot",
     "regression",
     "test",

--- a/src/matchSnapshot.js
+++ b/src/matchSnapshot.js
@@ -23,9 +23,9 @@ module.exports = function (value, context) {
   let snapDidChange = true
 
   if (snaps.hasOwnProperty(testName)) {
-    const existingSnap = stringify(snaps[ testName ])
+    const existingSnap = snaps[ testName ]
     const newSnap      = stringify(target)
-    const diffResult   = jsDiff.diffLines(existingSnap, newSnap)
+    const diffResult   = jsDiff.diffLines(existingSnap, newSnap, { ignoreWhitespace: true, newlineIsToken: true })
 
     snapDidChange = diffResult.some(it => it.removed || it.added)
 
@@ -36,7 +36,7 @@ module.exports = function (value, context) {
   }
 
   if (snapDidChange) {
-    snaps[ testName ] = target
+    snaps[ testName ] = stringify(target)
     persistSnaps(snaps, snapshotFilePath)
   }
 }

--- a/src/persistSnaps.js
+++ b/src/persistSnaps.js
@@ -6,7 +6,7 @@ module.exports = function(snaps, snapshotFilePath) {
   checkCI();
 
   const snapsFileContent = Object.keys(snaps)
-    .reduce((prev, curr) => `${prev}exports["${curr}"] = ${stringify(snaps[ curr ])};\n\n`, '');
+    .reduce((prev, curr) => `${prev}exports["${curr}"] = \`${stringify(snaps[ curr ])}\`;\n\n`, '');
 
   fs.writeFileSync(snapshotFilePath, snapsFileContent, { flag: 'w' });
 };

--- a/src/persistSnaps.js
+++ b/src/persistSnaps.js
@@ -6,7 +6,7 @@ module.exports = function(snaps, snapshotFilePath) {
   checkCI();
 
   const snapsFileContent = Object.keys(snaps)
-    .reduce((prev, curr) => `${prev}exports["${curr}"] = \`${stringify(snaps[ curr ])}\`;\n\n`, '');
+    .reduce((prev, curr) => `${prev}exports["${curr}"] = \`${stringify(snaps[ curr ]).replace(/\\/g, '\\\\')}\`;\n\n`, '');
 
   fs.writeFileSync(snapshotFilePath, snapsFileContent, { flag: 'w' });
 };

--- a/src/stringify.js
+++ b/src/stringify.js
@@ -1,8 +1,12 @@
-function ignoreNulls(key,value) {
-  if (value === null) return undefined
-  return value
-}
+const prettyFormat = require('pretty-format');
+const ReactElement = prettyFormat.plugins.ReactElement;
+const ReactTestComponent = prettyFormat.plugins.ReactTestComponent;
+
 
 module.exports = function stringify(obj) {
-  return JSON.stringify(obj, ignoreNulls, '  ');
+  if (typeof obj === "string")
+      return obj;
+  return prettyFormat(obj, {
+      plugins: [ReactElement, ReactTestComponent],
+  });
 };

--- a/tests/__snapshots__/matchSnapshot.test.js.mocha-snapshot
+++ b/tests/__snapshots__/matchSnapshot.test.js.mocha-snapshot
@@ -1,51 +1,25 @@
-exports["matchSnapshot/should match snapshots(0)"] = {
-  "node": {
-    "nodeType": "host",
-    "type": "div",
-    "props": {
-      "className": "abc",
-      "children": "Lorem Ipsum dolor"
-    },
-    "rendered": "Lorem Ipsum dolor"
-  },
-  "type": "div",
-  "props": {
-    "className": "abc"
-  },
-  "children": [
-    "Lorem Ipsum dolor"
-  ]
-};
+exports["matchSnapshot/should match snapshots(0)"] = `<div
+  className="abc"
+>
+  Lorem Ipsum dolor
+</div>`;
 
-exports["matchSnapshot/should match snapshots(1)"] = 123;
+exports["matchSnapshot/should match snapshots(1)"] = `123`;
 
-exports["matchSnapshot/should match snapshots(2)"] = {
+exports["matchSnapshot/should match snapshots(2)"] = `Object {
   "a": 1,
-  "b": {
-    "c": "lorem"
-  }
-};
-
-exports["matchSnapshot/should match snapshots without classNames sanitization(0)"] = {
-  "node": {
-    "nodeType": "host",
-    "type": "div",
-    "props": {
-      "className": "abc-123-45",
-      "children": "Lorem Ipsum dolor"
-    },
-    "rendered": "Lorem Ipsum dolor"
+  "b": Object {
+    "c": "lorem",
   },
-  "type": "div",
-  "props": {
-    "className": "abc-123-45"
-  },
-  "children": [
-    "Lorem Ipsum dolor"
-  ]
-};
+}`;
 
-exports["matchSnapshot/multiple tests with same it() title/title one/should match snapshot(0)"] = 123;
+exports["matchSnapshot/should match snapshots without classNames sanitization(0)"] = `<div
+  className="abc-123-45"
+>
+  Lorem Ipsum dolor
+</div>`;
 
-exports["matchSnapshot/multiple tests with same it() title/title two/should match snapshot(0)"] = 321;
+exports["matchSnapshot/multiple tests with same it() title/title one/should match snapshot(0)"] = `123`;
+
+exports["matchSnapshot/multiple tests with same it() title/title two/should match snapshot(0)"] = `321`;
 

--- a/tests/__snapshots__/matchSnapshot.test.js.mocha-snapshot
+++ b/tests/__snapshots__/matchSnapshot.test.js.mocha-snapshot
@@ -13,6 +13,15 @@ exports["matchSnapshot/should match snapshots(2)"] = `Object {
   },
 }`;
 
+exports["matchSnapshot/should match snapshots with double quotes(0)"] = `<div
+  argument="\\"\\""
+  className="abc"
+>
+  Lorem Ipsum dolor 
+  ""
+   ""
+</div>`;
+
 exports["matchSnapshot/should match snapshots without classNames sanitization(0)"] = `<div
   className="abc-123-45"
 >

--- a/tests/matchSnapshot.test.js
+++ b/tests/matchSnapshot.test.js
@@ -14,6 +14,14 @@ function MyReactComponent() {
   )
 }
 
+function MyReactComponentWithSpecialCharacters({argument}) {
+  return (
+    <div className="abc-123-45" argument={argument}>
+      Lorem Ipsum dolor {argument} ""
+    </div>
+  )
+}
+
 describe('matchSnapshot', () => {
   describe('multiple tests with same it() title', () => {
     describe('title one', () => {
@@ -35,6 +43,12 @@ describe('matchSnapshot', () => {
     expect(wrapper).to.matchSnapshot()
     expect(123).to.matchSnapshot()
     expect({ a: 1, b: { c: 'lorem' } }).to.matchSnapshot()
+  })
+
+  it('should match snapshots with double quotes', () => {
+    const wrapper = shallow(<MyReactComponentWithSpecialCharacters argument={'""'} />)
+
+    expect(wrapper).to.matchSnapshot()
   })
 
   it('should match snapshots without classNames sanitization', () => {


### PR DESCRIPTION
JSON is not really suitable for diffs, especially of React component. pretty-format is much better.

Example after:
```
exports["Domain deletion/delete domain(0)"] = `<Dialog
  autoStackButtons={true}
  className=""
  escapeKeyAction="close"
  id="mdc-dialog"
  onClose="[function]"
  onClosing="onClosing"
  onOpening="onOpening"
  open={true}
  role="alertdialog"
  scrimClickAction="close"
  tag="div"
>
  <DialogContent>
    Are you sure you want to delete 
    <b>
      test.com
    </b>
     domain?
  </DialogContent>
  <DialogFooter>
    <DialogButton
      data-kind="cancel-deletion"
      onClick="[function]"
      type="button"
    >
      Cancel
    </DialogButton>
    <DialogButton
      data-kind="delete-domain"
      onClick="[function]"
      type="button"
    >
      Delete
    </DialogButton>
  </DialogFooter>
</Dialog>`;

```

Example before:
![image](https://user-images.githubusercontent.com/75169/57443745-73152e80-7257-11e9-88a6-56144c0abcc4.png)
