### PR TITLE
fix: parsing UPDATE env var

### DIFF
--- a/src/matchSnapshot.js
+++ b/src/matchSnapshot.js
@@ -9,7 +9,7 @@ const getTestName         = require('./getTestName')
 
 const snapshotExtension     = '.mocha-snapshot'
 const snapshotsFolder       = '__snapshots__'
-const shouldUpdateSnapshots = process.env.UPDATE || process.argv.includes('--update')
+const shouldUpdateSnapshots = parseInt(process.env.UPDATE, 10) || process.argv.includes('--update')
 
 module.exports = function (value, context) {
   const dirName          = path.dirname(context.runnable.file)


### PR DESCRIPTION
Since the environment variable `UPDATE` was not being parsed at an integer value, having it set to anything would trigger the snapshot updates, which is fixed by this PR.